### PR TITLE
Set dynamic page titles for projects and dashboard components

### DIFF
--- a/src/app/components/dashboard/dashboard.component.ts
+++ b/src/app/components/dashboard/dashboard.component.ts
@@ -18,12 +18,10 @@ import {CreateThreadModalComponent} from "../create-thread-modal/create-thread-m
   imports: [
     ThreadComponent,
     AsyncPipe,
-    SlicePipe,
     NgIf,
     TripcodePillComponent,
     NgOptimizedImage,
     MatDialogModule,
-    CreateThreadModalComponent
   ],
   templateUrl: './dashboard.component.html',
   styleUrl: './dashboard.component.scss'
@@ -53,7 +51,7 @@ export class DashboardComponent extends Destroyable implements OnInit {
         takeUntil(this.unsubscribe$)
       ).subscribe(thread => {
         this.threadData.next(thread)
-        this.titleService.setTitle(thread.title ?? 'Thread')
+        this.titleService.setTitle((thread.title ?? 'Thread' )+ ' | modmod[.fun]')
         const mainImageId = thread.imageIds[0]
         this.imageUrl = `${this.environmentService.apiHost}/images/${mainImageId}`
         console.log(thread)

--- a/src/app/components/projects/projects.component.ts
+++ b/src/app/components/projects/projects.component.ts
@@ -11,6 +11,7 @@ import {Destroyable} from "../base/destroyable/destroyable.component";
 import {TripcodePillComponent} from "../tripcode-pill/tripcode-pill.component";
 import {ImageService} from "../../services/image.service";
 import {EnvironmentService} from "../../../environments/environment.service";
+import {Title} from "@angular/platform-browser";
 
 @Component({
   selector: 'app-projects',
@@ -39,7 +40,8 @@ export class ProjectsComponent extends Destroyable implements OnInit {
     private matDialog: MatDialog,
     private threadService: ThreadService,
     private imageService: ImageService,
-    private environmentService: EnvironmentService
+    private environmentService: EnvironmentService,
+    private titleService: Title
   ) {
     super();
   }
@@ -47,6 +49,8 @@ export class ProjectsComponent extends Destroyable implements OnInit {
   ngOnInit() {
     this.projects$ = this.projectService.getAllProjects()
     this.imagehost = `${this.environmentService.apiHost}/images/`;
+
+    this.titleService.setTitle('modmod[.fun]')
   }
 
   navigate(id: number) {


### PR DESCRIPTION
Added dynamic title setting using Title service to improve user experience and SEO. Updated the projects component to set a static title and refined the dashboard component to include thread titles with a consistent suffix.